### PR TITLE
修改.gitignore，忽略生成的缓存文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /app/controller/testAction.php
 /app/template/main/test.tpl.php
 /web/static/js/test*
+/logs/*
+/config/autoload.php
 


### PR DESCRIPTION
1、把框架运行过程中生成的logs加入到忽略文件。
2、框架运行时会对config/autoload.php写入内容，如果要把此文件也加入忽略文件列表，需要把config/autoload.php从版本库中移除。