### PR TITLE
TXAutoload两个小优化

### DIFF
--- a/lib/TXAutoload.php
+++ b/lib/TXAutoload.php
@@ -44,6 +44,7 @@ class TXAutoload
         $lastTime = is_readable(self::$autoPath) ? filemtime(self::$autoPath) : false;
         // 5秒缓存不更新
         if (!self::$loaders || !$lastTime || time()-$lastTime > self::$config['autoSkipLoad']){
+            $oldLoaders = (array)self::$loaders;
             self::$loaders = [];
             self::getLoads(__DIR__, 'biny\\lib\\');
             self::getLoads(TXApp::$extends_root);
@@ -54,11 +55,19 @@ class TXAutoload
             self::getLoads(TXApp::$app_root. DS . "form", 'app\\form\\');
             self::getLoads(TXApp::$app_root. DS . "event", 'app\\event\\');
             self::getLoads(TXApp::$app_root. DS . "model", 'app\\model\\');
-            //写入文件
-            if (!file_exists(self::$autoPath) || is_writeable(self::$autoPath)) {
-                file_put_contents(self::$autoPath, "<?php\nreturn " . var_export(self::$loaders, true) . ';', LOCK_EX);
-            } else {
-                throw new TXException(1005, [self::$autoPath]);
+
+            $needWrite = array_diff_assoc(self::$loaders, $oldLoaders) || array_diff_assoc($oldLoaders, self::$loaders)
+                    || array_diff_assoc(self::$loaders['namespace'], $oldLoaders['namespace']) || array_diff_assoc($oldLoaders['namespace'], self::$loaders['namespace'])
+                    || array_diff_assoc(self::$loaders['file'], $oldLoaders['file']) || array_diff_assoc($oldLoaders['file'], self::$loaders['file']);
+
+            if ($needWrite) { //与之前的不同，写入文件
+                if (!file_exists(self::$autoPath) || is_writeable(self::$autoPath)) {
+                    file_put_contents(self::$autoPath, "<?php\nreturn " . var_export(self::$loaders, true) . ';', LOCK_EX);
+                } else {
+                    throw new TXException(1005, [self::$autoPath]);
+                }
+            } else { //刷新更新时间
+                touch(self::$autoPath);
             }
         }
         return self::$loaders;

--- a/web/index.php
+++ b/web/index.php
@@ -17,7 +17,7 @@ include __DIR__.'/../lib/TXApp.php';
 //include __DIR__.'/../lib/XHProf.php';
 //XHProf::start();
 
-TXApp::registry(__DIR__. '/../app');
+TXApp::registry(realpath(__DIR__. '/../app'));
 TXApp::run();
 
 //$data = XHProf::end();


### PR DESCRIPTION
1. 调用`TXApp::registry`时，传目录绝对路径。 不然，在windows下，生成的config/autoload.php中会有正反斜杠同时存在。
2. 在`TXAutoload::loading`中，与之前加载结果不同，才重新写入文件，否则，只是刷新文件更新时间。可略微节省IO。