### PR TITLE
Update BinyException.php

### DIFF
--- a/lib/exception/BinyException.php
+++ b/lib/exception/BinyException.php
@@ -43,6 +43,7 @@ class BinyException extends \ErrorException
 
             } else {
                 if (App::$base->request->isShowTpl() || !App::$base->request->isAjax()){
+                    $params['webRoot'] = App::$base->router->rootPath;
                     echo new Response($this->config["exceptionTpl"], ['msg'=>$this->config['messages'][$html] ?: "系统数据异常：$html"], $params);
                 } else {
                     $data = ["flag" => false, "error" => $this->config['messages'][$html] ?: "系统数据异常：$html"];


### PR DESCRIPTION
第 46 行新增： $params['webRoot'] = App::$base->router->rootPath;

原因： 当关闭DEBUG模式后出现 controller/action 不存在的情况后会抛出 Response 异常，但是没有经过app层导致不会获取到 webRoot 参数，导致 exception.tpl.php 无法接收到 webRoot 参数从而无法获取到样式表。

比如：
Failed to load resource: the server responded with a status of 404 (Not Found)
uikit.min.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)
ydy.png:1 Failed to load resource: the server responded with a status of 404 (Not Found)
main.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)
custom.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)
uikit-icons.min.js:1 Failed to load resource: the server responded with a status of 404 (Not Found)
uikit.min.js:1 Failed to load resource: the server responded with a status of 404 (Not Found)
font.ttf:1 Failed to load resource: the server responded with a status of 404 (Not Found)
ydy.png:1 Failed to load resource: the server responded with a status of 404 (Not Found)
uikit-icons.min.js:1 Failed to load resource: the server responded with a status of 404 (Not Found)
123:1 Failed to load resource: the server responded with a status of 404 (Not Found)
main.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)
custom.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)
uikit.min.css:1 Failed to load resource: the server responded with a status of 404 (Not Found)